### PR TITLE
Don't play the equaliser animation when TrackWidget isn't visible

### DIFF
--- a/app/client/Widgets/TrackWidget.cpp
+++ b/app/client/Widgets/TrackWidget.cpp
@@ -152,7 +152,15 @@ TrackWidget::clearSpinner()
 void
 TrackWidget::showEvent(QShowEvent *)
 {
+    if ( m_nowPlaying )
+        m_movie->start();
     fetchAlbumArt();
+}
+
+void
+TrackWidget::hideEvent( QHideEvent * event )
+{
+    m_movie->stop();
 }
 
 void
@@ -197,6 +205,7 @@ TrackWidget::setTrack( lastfm::Track& track )
     connect( m_track.signalProxy(), SIGNAL(scrobbleStatusChanged(short)), SLOT(onScrobbleStatusChanged()));
     connect( m_track.signalProxy(), SIGNAL(corrected(QString)), SLOT(onCorrected(QString)));
 
+    m_movie->stop();
     ui->equaliser->hide();
     ui->asterisk->hide();
 
@@ -373,7 +382,8 @@ TrackWidget::updateTimestamp()
 
     if ( m_nowPlaying )
     {
-        m_movie->start();
+        if ( isVisible() )
+            m_movie->start();
         ui->equaliser->show();
 
         ui->timestamp->setText( tr( "Now listening" ) );

--- a/app/client/Widgets/TrackWidget.h
+++ b/app/client/Widgets/TrackWidget.h
@@ -70,6 +70,7 @@ private:
 
     void resizeEvent(QResizeEvent *);
     void showEvent(QShowEvent *);
+    void hideEvent(QHideEvent *);
     void contextMenuEvent( QContextMenuEvent* event );
 
     void fetchAlbumArt();


### PR DESCRIPTION
One TrackWidget was constantly playing icon_eq.gif no matter what.  This
caused the client to use cpu even when idle.  It now plays the animation
only when a track is playing and the widget is visible.
