### PR TITLE
No legacy player listener for unix:!mac

### DIFF
--- a/app/client/Services/ScrobbleService/ScrobbleService.cpp
+++ b/app/client/Services/ScrobbleService/ScrobbleService.cpp
@@ -25,7 +25,9 @@
 #include "lib/listener/DBusListener.h"
 #endif
 #include "../../Application.h"
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
 #include "lib/listener/legacy/LegacyPlayerListener.h"
+#endif
 #include "lib/listener/PlayerConnection.h"
 #include "lib/listener/PlayerListener.h"
 #include "lib/listener/PlayerMediator.h"
@@ -64,8 +66,10 @@ ScrobbleService::ScrobbleService()
 
         QObject* o = new PlayerListener(m_mediator);
         connect(o, SIGNAL(newConnection(PlayerConnection*)), m_mediator, SLOT(follow(PlayerConnection*)));
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
         o = new LegacyPlayerListener(m_mediator);
         connect(o, SIGNAL(newConnection(PlayerConnection*)), m_mediator, SLOT(follow(PlayerConnection*)));
+#endif
 
 #ifdef QT_DBUS_LIB
         DBusListener* dbus = new DBusListener(mediator);

--- a/lib/listener/listener.pro
+++ b/lib/listener/listener.pro
@@ -36,6 +36,11 @@ HEADERS += \
 	PlayerCommand.h \
         legacy/LegacyPlayerListener.h
 
+unix:!mac {
+    SOURCES -= legacy/LegacyPlayerListener.cpp
+    HEADERS -= legacy/LegacyPlayerListener.h
+}
+
 mac {
     SOURCES += mac/ITunesListener.cpp
 


### PR DESCRIPTION
The linux client no longer listens on tcp 33367.
The lastfm_scrobsub socket should work just as well.
