### PR TITLE
Raise/Hide Last.fm checkbox does not work in Advanced Settings

### DIFF
--- a/app/client/Application.cpp
+++ b/app/client/Application.cpp
@@ -304,8 +304,15 @@ Application::init()
 
     m_toggle_window_action = new QAction( this ), SLOT( trigger());
 #ifndef Q_WS_X11
-     AudioscrobblerSettings settings;
-     setRaiseHotKey( settings.raiseShortcutModifiers(), settings.raiseShortcutKey() );
+    AudioscrobblerSettings settings;
+    if ( settings.raiseShortcutEnabled() )
+    {
+        setRaiseHotKey( settings.raiseShortcutModifiers(), settings.raiseShortcutKey() );
+    }
+    else
+    {
+        unsetRaiseHotKey();
+    }
 #endif
     m_skip_action->setShortcut( Qt::CTRL + Qt::Key_Right );
     m_tag_action->setShortcut( Qt::CTRL + Qt::Key_T );
@@ -428,10 +435,18 @@ Application::showAs( bool showAs )
 }
 
 void
-Application::setRaiseHotKey( Qt::KeyboardModifiers mods, int key )
+Application::unsetRaiseHotKey()
 {
     if( m_raiseHotKeyId >= 0 )
         unInstallHotKey( m_raiseHotKeyId );
+    m_raiseHotKeyId = (void*)-1;
+}
+
+void
+Application::setRaiseHotKey( Qt::KeyboardModifiers mods, int key )
+{
+    // unset the raise hotkey if needed
+    unsetRaiseHotKey();
 
     m_raiseHotKeyId = installHotKey( mods, key, m_toggle_window_action, SLOT(trigger()));
 }

--- a/app/client/Application.h
+++ b/app/client/Application.h
@@ -141,6 +141,7 @@ namespace audioscrobbler
 
         void setBetaUpdates( bool betaUpdates );
 
+        void unsetRaiseHotKey();
         void setRaiseHotKey( Qt::KeyboardModifiers mods, int key );
 
         void startBootstrap( const QString& pluginId );

--- a/app/client/AudioscrobblerSettings.cpp
+++ b/app/client/AudioscrobblerSettings.cpp
@@ -24,6 +24,13 @@ AudioscrobblerSettings::AudioscrobblerSettings()
 {
 }
 
+bool
+AudioscrobblerSettings::raiseShortcutEnabled() const
+{
+    const bool fEnabled = true;
+    return value( "raiseShortcutEnabled", fEnabled ).toBool();
+}
+
 Qt::KeyboardModifiers
 AudioscrobblerSettings::raiseShortcutModifiers() const
 {
@@ -47,6 +54,12 @@ QString
 AudioscrobblerSettings::raiseShortcutDescription() const
 {
     return value( "raiseShortcutDescription", QString::fromUtf8( "⌃⌘ S" ) ).toString();
+}
+
+void
+AudioscrobblerSettings::setRaiseShortcutEnabled( bool f )
+{
+    setValue( "raiseShortcutEnabled", f );
 }
 
 void

--- a/app/client/AudioscrobblerSettings.h
+++ b/app/client/AudioscrobblerSettings.h
@@ -28,10 +28,12 @@ class AudioscrobblerSettings : public unicorn::AppSettings
 public:
     AudioscrobblerSettings();
 
+    bool raiseShortcutEnabled() const;
     Qt::KeyboardModifiers raiseShortcutModifiers() const;
     int raiseShortcutKey() const;
     QString raiseShortcutDescription() const;
 
+    void setRaiseShortcutEnabled( bool f );
     void setRaiseShortcutKey( int key );
     void setRaiseShortcutModifiers( Qt::KeyboardModifiers m );
     void setRaiseShortcutDescription( QString d );

--- a/app/client/Settings/AdvancedSettingsWidget.cpp
+++ b/app/client/Settings/AdvancedSettingsWidget.cpp
@@ -60,6 +60,7 @@ AdvancedSettingsWidget::AdvancedSettingsWidget( QWidget* parent )
     ui->shortcuts->hide();
 #else
 
+    ui->open->setChecked( settings.raiseShortcutEnabled() );
     ui->sce->setTextValue( settings.raiseShortcutDescription() );
     ui->sce->setModifiers( settings.raiseShortcutModifiers() );
     ui->sce->setKey( settings.raiseShortcutKey() );
@@ -83,11 +84,19 @@ AdvancedSettingsWidget::saveSettings()
     if ( hasUnsavedChanges() )
     {
         AudioscrobblerSettings settings;
+        settings.setRaiseShortcutEnabled( ui->open->isChecked() );
         settings.setRaiseShortcutKey( ui->sce->key() );
         settings.setRaiseShortcutModifiers( ui->sce->modifiers() );
         settings.setRaiseShortcutDescription( ui->sce->textValue() );
 
-        aApp->setRaiseHotKey( ui->sce->modifiers(), ui->sce->key() );
+        if ( ui->open->isChecked() )
+        {
+            aApp->setRaiseHotKey( ui->sce->modifiers(), ui->sce->key() );
+        }
+        else
+        {
+            aApp->unsetRaiseHotKey();
+        }
 
         ui->proxySettings->save();
 

--- a/app/client/Settings/AdvancedSettingsWidget.ui
+++ b/app/client/Settings/AdvancedSettingsWidget.ui
@@ -23,13 +23,10 @@
       <item>
        <widget class="QCheckBox" name="open">
         <property name="enabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="text">
          <string>Raise/Hide Last.fm</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
The Raise/Hide checkbox in the Advanced pane of the application Preferences is checked and disabled.  This checkbox should enable or disable the function of the system-wide hotkey which raises the Last.fm Scrobbler client window to front.

There is a Last.fm forum entry complaining about the hotkey keyboard shortcut here:
- [Last.fm forum bug report: Unable to change Keyboard shortcuts](http://www.last.fm/forum/34905/_/2199781)

Implementing the raise/hide checkbox functionality should make some of these people less grumpy.

Here's how the hotkey is implemented in the current codebase:
- [Location of HotKey installation: lastfm-desktop/app/client/Application.cpp](https://github.com/lastfm/lastfm-desktop/blob/fc664d1b2da8e8777525e03798b3d0e1444ebe2e/app/client/Application.cpp#L308)
- [Underlying implementation in: lastfm-desktop/lib/unicorn/UnicornApplication.cpp](https://github.com/lastfm/lastfm-desktop/blob/fc664d1b2da8e8777525e03798b3d0e1444ebe2e/lib/unicorn/UnicornApplication.cpp#L405)

Some useful links for how to implement system-wide HotKeys (Mac OS X-specific):
- [Cocoa Tips and Tricks: How to add a HotKey Listener](http://cocoatutorial.grapewave.com/tag/hotkey/)
- [Mac virtual key-codes](http://boredzo.org/blog/archives/2007-05-22/virtual-key-codes)

This pull request contains a few changes which hopefully will get this checkbox button working in the UI.  **Warning:** I have not been able to test this commit.  Can anyone confirm that this code works?

PS: [Issue #30](https://github.com/lastfm/lastfm-desktop/issues/30) is a duplicate of this pull request.  Sorry.
