### PR TITLE
Fix build issue

### DIFF
--- a/app/client/Application.cpp
+++ b/app/client/Application.cpp
@@ -430,7 +430,7 @@ Application::showAs( bool showAs )
 void
 Application::setRaiseHotKey( Qt::KeyboardModifiers mods, int key )
 {
-    if( m_raiseHotKeyId >= 0 )
+    if( m_raiseHotKeyId >= (void *)0 )
         unInstallHotKey( m_raiseHotKeyId );
 
     m_raiseHotKeyId = installHotKey( mods, key, m_toggle_window_action, SLOT(trigger()));


### PR DESCRIPTION
Fix build error on FreeBSD 10.x+

```
Application.cpp:433:25: error: ordered comparison between pointer and zero ('void *' and 'int')
```