### PR TITLE
Support Scrobbling on MacOS Catalina

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ admin/dist/mac/dsa_priv.pem
 *.user
 *.qm
 *.exe
+*.vscode
+Growl
+Sparkle

--- a/admin/dist/mac/Standard.plist
+++ b/admin/dist/mac/Standard.plist
@@ -32,6 +32,8 @@
 	<string>AppleScriptSuite.sdef</string>
 	<key>NSAppleScriptEnabled</key>
 	<true/>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Allow Last.fm to Scrobble music you are listening to.</string>
 	<key>BreakpadProduct</key>
 	<string>@EXECUTABLE@</string>
 	<key>BreakpadVendor</key>

--- a/admin/dist/mac/Standard.plist
+++ b/admin/dist/mac/Standard.plist
@@ -33,7 +33,7 @@
 	<key>NSAppleScriptEnabled</key>
 	<true/>
 	<key>NSAppleEventsUsageDescription</key>
-	<string>Allow Last.fm to listen for AppleEvents.</string>
+	<string>For Music and iTunes, this enables scrobbling. For Spotify, this lets you see Last.fm info about the currently playing song.</string>
 	<key>BreakpadProduct</key>
 	<string>@EXECUTABLE@</string>
 	<key>BreakpadVendor</key>

--- a/admin/dist/mac/Standard.plist
+++ b/admin/dist/mac/Standard.plist
@@ -33,7 +33,7 @@
 	<key>NSAppleScriptEnabled</key>
 	<true/>
 	<key>NSAppleEventsUsageDescription</key>
-	<string>Allow Last.fm to Scrobble music you are listening to.</string>
+	<string>Allow Last.fm to listen for AppleEvents.</string>
 	<key>BreakpadProduct</key>
 	<string>@EXECUTABLE@</string>
 	<key>BreakpadVendor</key>

--- a/admin/dist/mac/bundleFrameworks.sh
+++ b/admin/dist/mac/bundleFrameworks.sh
@@ -159,10 +159,10 @@ plugins="imageformats sqldrivers bearer"
 for plugin in $plugins; do
     if [ -d /Developer/Applications/Qt/plugins/ ]; then
         pluginDir=/Developer/Applications/Qt/plugins
-    elif [ -d /usr/local/Cellar/qt@4/4.8.7_5/lib/qt4/plugins/ ]; then
-        # Qt installed using Homebrew will be found in the Homebrew Cellar.
+    elif [ -d /usr/local/lib/qt4/plugins/ ]; then
+        # Qt installed using Homebrew will be found in your local lib.
         # Currently we only support qt v4.8.7.
-        pluginDir=/usr/local/Cellar/qt@4/4.8.7_5/lib/qt4/plugins
+        pluginDir=/usr/local/lib/qt4/plugins
     else
         pluginDir=`qmake --version |sed -n 's/^.*in \(\/.*$\)/\1/p'`/../plugins
     fi

--- a/admin/dist/mac/bundleFrameworks.sh
+++ b/admin/dist/mac/bundleFrameworks.sh
@@ -159,6 +159,8 @@ plugins="imageformats sqldrivers bearer"
 for plugin in $plugins; do
     if [ -d /Developer/Applications/Qt/plugins/ ]; then
         pluginDir=/Developer/Applications/Qt/plugins
+    elif [ -d /usr/local/lib/qt4/plugins/ ]; then
+        pluginDir=/usr/local/lib/qt4/plugins/
     else
         pluginDir=`qmake --version |sed -n 's/^.*in \(\/.*$\)/\1/p'`/../plugins
     fi
@@ -177,18 +179,18 @@ mkdir -p "$bundlePath/Contents/Resources/qm"
 translations="qt_de.qm
                 qt_es.qm 
                 qt_fr.qm 
-                qt_it.qm 
                 qt_ja.qm 
                 qt_pl.qm 
                 qt_pt.qm 
                 qt_ru.qm 
                 qt_sv.qm 
-                qt_tr.qm
                 qt_zh_CN.qm"
 
 for translation in $translations; do
     if [ -d /Developer/Applications/Qt/plugins/ ]; then
         translationDir=/Developer/Applications/Qt/translations
+    elif [ -d /usr/local/Cellar/qt@4/4.8.7_5/translations/ ]; then
+        translationDir=/usr/local/Cellar/qt@4/4.8.7_5/translations
     else
         translationDir=`qmake --version |sed -n 's/^.*in \(\/.*$\)/\1/p'`/../translations
     fi

--- a/admin/dist/mac/bundleFrameworks.sh
+++ b/admin/dist/mac/bundleFrameworks.sh
@@ -159,8 +159,10 @@ plugins="imageformats sqldrivers bearer"
 for plugin in $plugins; do
     if [ -d /Developer/Applications/Qt/plugins/ ]; then
         pluginDir=/Developer/Applications/Qt/plugins
-    elif [ -d /usr/local/lib/qt4/plugins/ ]; then
-        pluginDir=/usr/local/lib/qt4/plugins/
+    elif [ -d /usr/local/Cellar/qt@4/4.8.7_5/lib/qt4/plugins/ ]; then
+        # Qt installed using Homebrew will be found in the Homebrew Cellar.
+        # Currently we only support qt v4.8.7.
+        pluginDir=/usr/local/Cellar/qt@4/4.8.7_5/lib/qt4/plugins
     else
         pluginDir=`qmake --version |sed -n 's/^.*in \(\/.*$\)/\1/p'`/../plugins
     fi
@@ -190,6 +192,8 @@ for translation in $translations; do
     if [ -d /Developer/Applications/Qt/plugins/ ]; then
         translationDir=/Developer/Applications/Qt/translations
     elif [ -d /usr/local/Cellar/qt@4/4.8.7_5/translations/ ]; then
+        # Qt installed using Homebrew will be found in the Homebrew Cellar.
+        # Currently we only support qt v4.8.7.
         translationDir=/usr/local/Cellar/qt@4/4.8.7_5/translations
     else
         translationDir=`qmake --version |sed -n 's/^.*in \(\/.*$\)/\1/p'`/../translations

--- a/admin/dist/win/Last.fm.iss
+++ b/admin/dist/win/Last.fm.iss
@@ -154,13 +154,11 @@ Source: "..\..\..\i18n\*.qm"; DestDir: "{app}\i18n"; Flags: ignoreversion
 Source: "%QTDIR%\translations\qt_de.qm"; DestDir: "{app}\i18n"; Flags: ignoreversion
 Source: "%QTDIR%\translations\qt_es.qm"; DestDir: "{app}\i18n"; Flags: ignoreversion
 Source: "%QTDIR%\translations\qt_fr.qm"; DestDir: "{app}\i18n"; Flags: ignoreversion
-;Source: "%QTDIR%\translations\qt_it.qm"; DestDir: "{app}\i18n"; Flags: ignoreversion
 Source: "%QTDIR%\translations\qt_ja.qm"; DestDir: "{app}\i18n"; Flags: ignoreversion
 Source: "%QTDIR%\translations\qt_pl.qm"; DestDir: "{app}\i18n"; Flags: ignoreversion
 Source: "%QTDIR%\translations\qt_pt.qm"; DestDir: "{app}\i18n"; Flags: ignoreversion
 Source: "%QTDIR%\translations\qt_ru.qm"; DestDir: "{app}\i18n"; Flags: ignoreversion
 Source: "%QTDIR%\translations\qt_sv.qm"; DestDir: "{app}\i18n"; Flags: ignoreversion
-;Source: "%QTDIR%\translations\qt_tr.qm"; DestDir: "{app}\i18n"; Flags: ignoreversion
 Source: "%QTDIR%\translations\qt_zh_CN.qm"; DestDir: "{app}\i18n"; Flags: ignoreversion
 
 ;The add/modify/remove file

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,5 @@
+TBA
+- Support Scrobbling on MacOS Catalina.
+
+2.1.37
+- Start of changelog.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,0 @@
-TBA
-- Support Scrobbling on MacOS Catalina.
-
-2.1.37
-- Start of changelog.

--- a/lib/listener/mac/ITunesListener.h
+++ b/lib/listener/mac/ITunesListener.h
@@ -39,7 +39,7 @@ signals:
     void newConnection( class PlayerConnection* );
     
 private:
-    static bool iTunesIsPlaying();
+    static QString getPlayerAppId();
 
     /** iTunes notification center callback */
     static void callback( CFNotificationCenterRef, 
@@ -50,12 +50,15 @@ private:
 
     void callback( CFDictionaryRef );
 
+    bool isPlaying();
+
 private slots:
     void setupCurrentTrack();
 
 private:
     State m_state;
     QString m_previousPid;
+    QString m_playerAppId;
     struct ITunesConnection* m_connection;
 
     AppleScript m_currentTrackScript;


### PR DESCRIPTION
### Breaking changes in MacOS Mojave:
MacOS Mojave introduces more stringent permissions surrounding AppleEvents.
We must include `NSAppleEventsUsageDescription` in the plist to grant the app permissions to talk to other apps via AppleEvents.  

### Breaking changes in MacOS Catalina:
MacOS Catalina no longer comes installed with iTunes (replaced with Apple Music). 
We need to detect which music player is installed to support Scrobbling on Catalina. 
